### PR TITLE
refactor: stop filtering out delta components with zero amount

### DIFF
--- a/Test/Delta.juvix
+++ b/Test/Delta.juvix
@@ -9,8 +9,7 @@ type DeltaMap := mkDeltaMap {unDeltaMap : Map Kind DeltaComponent};
 
 amountIsZero : DeltaComponent -> Bool := DeltaComponent.amount >> (/=) 0;
 
-toDelta : DeltaMap -> Delta :=
-  DeltaMap.unDeltaMap >> Map.toList >> filter (snd >> amountIsZero) >> map snd;
+toDelta : DeltaMap -> Delta := DeltaMap.unDeltaMap >> Map.toList >> map snd;
 
 emptyDeltaMap : DeltaMap := mkDeltaMap Map.empty;
 

--- a/Test/Delta.juvix
+++ b/Test/Delta.juvix
@@ -13,6 +13,12 @@ toDelta : DeltaMap -> Delta := DeltaMap.unDeltaMap >> Map.toList >> map snd;
 
 emptyDeltaMap : DeltaMap := mkDeltaMap Map.empty;
 
+computeDelta (consumed : List Resource) (created : List Resource) : Delta :=
+  let
+    withCreatedDelta : DeltaMap := for (acc := emptyDeltaMap) (r in created) addDelta acc r;
+    withConsumedDelta : DeltaMap := for (acc := withCreatedDelta) (r in consumed) subDelta acc r;
+  in toDelta withConsumedDelta;
+
 appendDelta (sign : Bool) (m : DeltaMap) (r : Resource) : DeltaMap :=
   let
     rd := resourceDelta sign r;
@@ -28,10 +34,8 @@ subDelta : DeltaMap -> Resource -> DeltaMap :=
     sign := false
   };
 
-printDeltaMap (dm : DeltaMap) : String :=
-  let
-    delta := toDelta dm;
-  in if
+printDelta (delta : Delta) : String :=
+  if
     | null delta := "[Empty Delta]"
     | else :=
       unlines

--- a/Test/Transaction.juvix
+++ b/Test/Transaction.juvix
@@ -35,17 +35,16 @@ verifyResourceSet (tx : Transaction) (ctx : Context) : Context :=
 --- Check that the computed delta is equal to the Transaction delta
 verifyDelta (tx : Transaction) (ctx : Context) : Context :=
   let
-    rs := partitionResources tx;
-    withCreatedDelta :=
-      for (acc := emptyDeltaMap) (r in ResourcePartition.created rs)
-        addDelta acc r;
-    withConsumedDelta :=
-      for (acc := withCreatedDelta) (r in ResourcePartition.consumed rs)
-        subDelta acc r;
+    rs : ResourcePartition := partitionResources tx;
+    delta :=
+      computeDelta@{
+        consumed := ResourcePartition.consumed rs;
+        created := ResourcePartition.created rs
+      };
   in ctx
-    |> info ("Computed Delta\n" ++str printDeltaMap withConsumedDelta)
+    |> info ("Computed Delta\n" ++str printDelta delta)
     |> if
-      | Transaction.delta tx /= toDelta withConsumedDelta := Context.fail "... Delta invalid"
+      | Transaction.delta tx /= delta := Context.fail "... Delta invalid"
       | else := info "... Delta valid";
 
 --- Check that all logic functions are valid

--- a/tests/AnomaExample.juvix
+++ b/tests/AnomaExample.juvix
@@ -7,68 +7,89 @@ import Test.Anoma open;
 import Keys open;
 
 validTx : Transaction :=
-  let r := mkResource@{
-     publicKey := pubKey;
-     logicFn := \ { _ _ := true };
-     amount := 1
-   } in
-   mkTransaction@{
+  let
+    r :=
+      mkResource@{
+        publicKey := pubKey;
+        logicFn := \ {_ _ := true};
+        amount := 1
+      };
+  in mkTransaction@{
     privateKey := privKey;
     consumed := [r];
     created := [r]
-};
+  };
 
 invalidLogicFnTx : Transaction :=
-  let r := mkResource@{
-     publicKey := pubKey;
-     logicFn := \ { _ _ := false };
-     amount := 1
-   } in
-   mkTransaction@{
+  let
+    r :=
+      mkResource@{
+        publicKey := pubKey;
+        logicFn := \ {_ _ := false};
+        amount := 1
+      };
+  in mkTransaction@{
     privateKey := privKey;
     consumed := [r];
     created := [r]
-};
+  };
 
-emptyProofsTx : Transaction :=
-  validTx@Transaction{proofs := []};
+emptyProofsTx : Transaction := validTx@Transaction{proofs := []};
 
 invalidPubKey : Transaction :=
-  let r := mkResource@{
-     publicKey := replicate 32 0x0 |> PublicKey.mk;
-     logicFn := \ { _ _ := true };
-     amount := 1
-   } in
-   mkTransaction@{
+  let
+    r :=
+      mkResource@{
+        publicKey := replicate 32 0x0 |> PublicKey.mk;
+        logicFn := \ {_ _ := true};
+        amount := 1
+      };
+  in mkTransaction@{
     privateKey := privKey;
     consumed := [r];
     created := [r]
-};
+  };
 
 nonMatchingDelta : Transaction :=
-  let r := mkResource@{
-     publicKey := pubKey;
-     logicFn := \ { _ _ := true };
-     amount := 1
-   } in
-   mkTransaction@{
+  let
+    r :=
+      mkResource@{
+        publicKey := pubKey;
+        logicFn := \ {_ _ := true};
+        amount := 1
+      };
+  in mkTransaction@{
     privateKey := privKey;
     consumed := [r@Resource{quantity := 2}];
     created := [r];
-    txDelta := [DeltaComponent.mk@{denom := anomaKind r; amount := 1; sign := true}]
-};
+    txDelta :=
+      [ DeltaComponent.mk@{
+        denom := anomaKind r;
+        amount := 1;
+        sign := true
+      }
+      ]
+  };
 
 matchingDelta : Transaction :=
-  let r := mkResource@{
-     publicKey := pubKey;
-     logicFn := \ { _ _ := true };
-     amount := 1
-   } in
-   mkTransaction@{
+  let
+    r :=
+      mkResource@{
+        publicKey := pubKey;
+        logicFn := \ {_ _ := true};
+        amount := 1
+      };
+  in mkTransaction@{
     privateKey := privKey;
     consumed := [r@Resource{quantity := 2}];
     created := [r];
-    txDelta := [DeltaComponent.mk@{denom := anomaKind r; amount := 1; sign := false}]
-};
+    txDelta :=
+      [ DeltaComponent.mk@{
+        denom := anomaKind r;
+        amount := 1;
+        sign := false
+      }
+      ]
+  };
 
 main : IO := mkMain (verify validTx);

--- a/tests/Main.juvix
+++ b/tests/Main.juvix
@@ -9,25 +9,23 @@ import Test.Simulator.MerkleTree open using {merkleTestSuite};
 
 main : IO :=
   runTestSuite
-    (testSuite
-      "Anoma tests"
-      [ testCase
-        "Valid transaction is valid"
-        (anomaAssertPass (verify validTx))
-      ; testCase
-        "Transaction with invalid logic function is invalid"
-        (anomaAssertFail (verify invalidLogicFnTx))
-      ; testCase
-        "Transaction with empty proofs is invalid"
-        (anomaAssertFail (verify emptyProofsTx))
-      ; testCase
-        "Transaction with invalid public key is invalid"
-        (anomaAssertFail (verify invalidPubKey))
-      ; testCase
-        "Transaction delta does not equal the delta sum is invalid"
-        (anomaAssertFail (verify nonMatchingDelta))
-      ; testCase
-        "Transaction delta equals the delta sum is valid"
-        (anomaAssertPass (verify matchingDelta))
-      ])
-  >>> runTestSuite merkleTestSuite;
+      (testSuite
+        "Anoma tests"
+        [ testCase "Valid transaction is valid" (anomaAssertPass (verify validTx))
+        ; testCase
+          "Transaction with invalid logic function is invalid"
+          (anomaAssertFail (verify invalidLogicFnTx))
+        ; testCase
+          "Transaction with empty proofs is invalid"
+          (anomaAssertFail (verify emptyProofsTx))
+        ; testCase
+          "Transaction with invalid public key is invalid"
+          (anomaAssertFail (verify invalidPubKey))
+        ; testCase
+          "Transaction delta does not equal the delta sum is invalid"
+          (anomaAssertFail (verify nonMatchingDelta))
+        ; testCase
+          "Transaction delta equals the delta sum is valid"
+          (anomaAssertPass (verify matchingDelta))
+        ])
+    >>> runTestSuite merkleTestSuite;

--- a/tests/Transaction.juvix
+++ b/tests/Transaction.juvix
@@ -2,12 +2,16 @@ module Transaction;
 
 import Stdlib.Prelude open;
 import Anoma open;
+import Test.Delta open;
 
 mkTransaction
   (privateKey : PrivateKey)
   (consumed : List Resource)
   (created : List Resource)
-  {txDelta : Delta := []}
+  {txDelta : Delta := computeDelta@{
+    consumed;
+    created
+  }}
   : Transaction :=
   Transaction.mk@{
     roots := [];
@@ -20,9 +24,7 @@ mkTransaction
   };
 
 mkResource
-  (publicKey : PublicKey)
-  (logicFn : Resource -> Transaction -> Bool)
-  (amount : Nat) : Resource :=
+  (publicKey : PublicKey) (logicFn : Resource -> Transaction -> Bool) (amount : Nat) : Resource :=
   Resource.mk@{
     logic := logicFn;
     label := 0;


### PR DESCRIPTION
This PR resolves issue https://github.com/anoma/juvix-anoma-test/issues/8 by
- removing `filter (snd >> amountIsZero)`
- adding automated `delta` calculation to the `txDelta` default argument of `mkTransaction` in `tests/Transaction.juvix`

and formats some unformatted files